### PR TITLE
Add /top command to teleport player to highest block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.estools</groupId>
   <artifactId>EsTools</artifactId>
-  <version>5.1.4</version>
+  <version>5.1.5</version>
   <packaging>jar</packaging>
 
   <name>EsTools</name>

--- a/src/main/java/net/estools/Commands/Top.java
+++ b/src/main/java/net/estools/Commands/Top.java
@@ -1,0 +1,25 @@
+package net.estools.Commands;
+
+import net.estools.EsToolsCommand;
+import net.estools.ServerApi.Interfaces.EsCommandSender;
+import net.estools.ServerApi.Interfaces.EsPlayer;
+import net.estools.ServerApi.EsLocation;
+
+public class Top extends EsToolsCommand {
+
+    @Override
+    public boolean execute(EsCommandSender sender, String[] args) {
+        if (isNotPlayer(sender)) {
+            return false;
+        }
+
+        EsPlayer player = (EsPlayer) sender;
+        EsLocation location = player.getLocation();
+        EsLocation highestBlockLocation = location.getWorld().getHighestBlockAt(location).getLocation();
+
+        player.teleport(highestBlockLocation);
+        send(player, "&aTeleported to the highest block at your location!");
+
+        return true;
+    }
+}

--- a/src/main/java/net/estools/Commands/Top.java
+++ b/src/main/java/net/estools/Commands/Top.java
@@ -1,25 +1,46 @@
 package net.estools.Commands;
 
-import net.estools.EsToolsCommand;
+import net.estools.PlayerCommand;
+import net.estools.ServerApi.Interfaces.EsBlock;
 import net.estools.ServerApi.Interfaces.EsCommandSender;
 import net.estools.ServerApi.Interfaces.EsPlayer;
 import net.estools.ServerApi.EsLocation;
+import net.estools.ServerApi.Position;
 
-public class Top extends EsToolsCommand {
+public class Top extends PlayerCommand {
 
     @Override
     public boolean execute(EsCommandSender sender, String[] args) {
-        if (isNotPlayer(sender)) {
+        EsPlayer player = null;
+        if (args.length == 0) {
+            if (isNotPlayer(sender)) {
+                return false;
+            }
+            player = (EsPlayer) sender;
+        } else if (args.length == 1) {
+            player = getPlayer(sender, args[0]);
+        } else {
+            send(sender, "&cUsage: /top [player]");
+        }
+
+        if (player == null) {
             return false;
         }
 
-        EsPlayer player = (EsPlayer) sender;
         EsLocation location = player.getLocation();
-        EsLocation highestBlockLocation = location.getWorld().getHighestBlockAt(location).getLocation();
+        EsBlock block = location.getWorld().getHighestBlockAt(location.getBlockX(), location.getBlockZ());
+        if (block == null) {
+            send(sender, "&cNo block could be found");
+            return false;
+        }
 
-        player.teleport(highestBlockLocation);
-        send(player, "&aTeleported to the highest block at your location!");
+        Position highestBlockPos = block.getLocation();
 
+        EsLocation newLoc = new EsLocation(location.getWorld(), location.getDirection(), highestBlockPos.add(0.5, 1, 0.5));
+        newLoc.setPitch(location.getPitch());
+        newLoc.setYaw(location.getYaw());
+        player.teleport(newLoc);
+        send(sender, "&aTeleported to the highest block at your location!");
         return true;
     }
 }

--- a/src/main/java/net/estools/Main.java
+++ b/src/main/java/net/estools/Main.java
@@ -158,6 +158,8 @@ public class Main {
 		sc("mount", "mount", new Mount());
 		sc("dismount", "mount", new Dismount());
 
+		sc("top", "top", new Top());
+
 		// Load other features
 		if (minecraftVersion.getMinor() > 0) {  // Enchants and events don't work on 1.0.0
 			PowerTool.init();
@@ -290,4 +292,3 @@ public class Main {
 		ConfigManager.save("config.yml", config);
 	}
 }
-

--- a/src/main/java/net/estools/ServerApi/EsLocation.java
+++ b/src/main/java/net/estools/ServerApi/EsLocation.java
@@ -28,6 +28,10 @@ public class EsLocation extends Position {
         setZ(z);
     }
 
+    public EsLocation(EsWorld world, Position dir, Position pos) {
+        this(world, dir, pos.getX(), pos.getY(), pos.getZ());
+    }
+
     public EsLocation(EsWorld world, Position dir, double x, double y, double z, double yaw, double pitch) {
         this.world = world;
         this.worldName = world.getName();
@@ -37,6 +41,10 @@ public class EsLocation extends Position {
         setX(x);
         setY(y);
         setZ(z);
+    }
+
+    public EsLocation(EsWorld world, Position pos) {
+        this(world, pos.getX(), pos.getY(), pos.getZ());
     }
 
     /** You probably shouldn't use this, it's here for SnakeYAML */
@@ -84,15 +92,15 @@ public class EsLocation extends Position {
     }
 
     public int getBlockX() {
-        return (int) Math.round(getX());
+        return (int) Math.floor(getX());
     }
 
     public int getBlockY() {
-        return (int) Math.round(getY());
+        return (int) Math.floor(getY());
     }
 
     public int getBlockZ() {
-        return (int) Math.round(getZ());
+        return (int) Math.floor(getZ());
     }
 
     public EsLocation add(Position other) {

--- a/src/main/java/net/estools/ServerApi/Implementations/Bukkit/BukkitWorld.java
+++ b/src/main/java/net/estools/ServerApi/Implementations/Bukkit/BukkitWorld.java
@@ -3,6 +3,7 @@ package net.estools.ServerApi.Implementations.Bukkit;
 import net.estools.Main;
 import net.estools.ServerApi.EsLocation;
 import net.estools.ServerApi.Implementations.Bukkit.Helpers.BukkitHelper;
+import net.estools.ServerApi.Interfaces.EsBlock;
 import net.estools.ServerApi.Interfaces.EsEntity;
 import net.estools.ServerApi.Interfaces.EsWorld;
 import org.bukkit.World;
@@ -61,6 +62,11 @@ public class BukkitWorld implements EsWorld {
             entities.add(BukkitHelper.fromBukkitEntity(bEntity));
         }
         return entities;
+    }
+
+    @Override
+    public EsBlock getHighestBlockAt(int x, int z) {
+        return BukkitHelper.fromBukkitBlock(bukkitWorld.getHighestBlockAt(x, z));
     }
 
     @Override

--- a/src/main/java/net/estools/ServerApi/Implementations/Folia/FoliaWorld.java
+++ b/src/main/java/net/estools/ServerApi/Implementations/Folia/FoliaWorld.java
@@ -2,6 +2,7 @@ package net.estools.ServerApi.Implementations.Folia;
 
 import net.estools.ServerApi.EsLocation;
 import net.estools.ServerApi.Implementations.Bukkit.BukkitWorld;
+import net.estools.ServerApi.Interfaces.EsBlock;
 import net.estools.ServerApi.Interfaces.EsEntity;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
@@ -36,6 +37,11 @@ public class FoliaWorld extends BukkitWorld {
             entities.add(FoliaHelper.fromBukkitEntity(bEntity));
         }
         return entities;
+    }
+
+    @Override
+    public EsBlock getHighestBlockAt(int x, int z) {
+        return FoliaHelper.fromBukkitBlock(bukkitWorld.getHighestBlockAt(x, z));
     }
 
     @Override

--- a/src/main/java/net/estools/ServerApi/Interfaces/EsBlock.java
+++ b/src/main/java/net/estools/ServerApi/Interfaces/EsBlock.java
@@ -1,5 +1,7 @@
 package net.estools.ServerApi.Interfaces;
 
+import net.estools.ServerApi.Position;
+
 @SuppressWarnings("unused")
 public interface EsBlock {
     boolean breakNaturally();
@@ -7,4 +9,8 @@ public interface EsBlock {
     int getY();
     int getZ();
     String getType();
+
+    default Position getLocation() {
+        return new Position(getX(), getY(), getZ());
+    }
 }

--- a/src/main/java/net/estools/ServerApi/Interfaces/EsWorld.java
+++ b/src/main/java/net/estools/ServerApi/Interfaces/EsWorld.java
@@ -10,6 +10,15 @@ public interface EsWorld {
     UUID getUuid();
     List<EsEntity> getEntities();
     List<EsEntity> getNearbyEntities(EsLocation loc, double xoff, double yoff, double zoff);
+
+    /**
+     * Get the highest block at the specific position.
+     * @param x The x position.
+     * @param z The z position.
+     * @return The highest block.
+     * @implNote Implementations may return either null or air if no block is found.
+     */
+    EsBlock getHighestBlockAt(int x, int z);
     void setTime(long time);
     void setStorming(boolean val);
     void setThundering(boolean val);

--- a/src/main/java/net/estools/ServerApi/Position.java
+++ b/src/main/java/net/estools/ServerApi/Position.java
@@ -51,6 +51,14 @@ public class Position {
         return new Position(x - other.x, y - other.y, z - other.z);
     }
 
+    public Position add(Position other) {
+        return new Position(x + other.x, y + other.y, z + other.z);
+    }
+
+    public Position add(double x, double y, double z) {
+        return add(new Position(x, y, z));
+    }
+
     public Position normalise() {
         double length = length();
         return new Position(x / length, y / length, z / length);
@@ -74,5 +82,10 @@ public class Position {
 
     public Position toPosition() {
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return getX() + ", " + getY() + ", " + getZ();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -193,6 +193,9 @@ commands:
   disposal:
     description: Open an inventory that isn't saved so that you can place items and easily get rid of them.
     usage: /disposal
+  top:
+    description: Teleports the player to the highest block at their coordinates.
+    usage: /top
 
 permissions:
   estools.update:
@@ -409,4 +412,7 @@ permissions:
 
   estools.disposal:
     description: Allows the player to open the disposal menu
+    default: op
+  estools.top:
+    description: Lets players teleport to the highest block at their coordinates
     default: op

--- a/src/test/java/net/estools/Commands/TopCommandTest.java
+++ b/src/test/java/net/estools/Commands/TopCommandTest.java
@@ -1,0 +1,50 @@
+package net.estools.Commands;
+
+import net.estools.EsToolsUnitTest;
+import net.estools.Implementation.TestPlayer;
+import net.estools.ServerApi.EsLocation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TopCommandTest extends EsToolsUnitTest {
+
+    @Test
+    public void noBlocks() {
+        resetWorld();
+        go(0, 0, 0);
+        executeAssertError("top");
+    }
+
+    @Test
+    public void above() {
+        resetWorld();
+        go(20, 60, 20);
+        world.addBlock(20, 90, 20);
+        executeAssertSuccess("top");
+        Assertions.assertEquals(91, player.getLocation().getBlockY());
+    }
+
+    @Test
+    public void below() {
+        resetWorld();
+        go(-20, 60, -20);
+        world.addBlock(-20, 20, -20);
+        executeAssertSuccess("top");
+        Assertions.assertEquals(21, player.getLocation().getBlockY());
+    }
+
+    @Test
+    public void withPlayer() {
+        resetWorld();
+        TestPlayer p1 = createPlayer();
+        p1.teleport(new EsLocation(world, 20, 60 ,20));
+        world.addBlock(20, 80, 20);
+        executeAssertSuccess("top " + p1.getName());
+        Assertions.assertEquals(81, p1.getLocation().getBlockY());
+    }
+
+    @Test
+    public void invalidPlayer() {
+        executeAssertOneError("top invalid");
+    }
+}

--- a/src/test/java/net/estools/EsToolsUnitTest.java
+++ b/src/test/java/net/estools/EsToolsUnitTest.java
@@ -81,6 +81,10 @@ public class EsToolsUnitTest {
         Assertions.assertEquals(shouldError, errored, msg);
     }
 
+    public void resetWorld() {
+        world = new TestWorld("testingworld");
+    }
+
     @BeforeAll
     public static void initEnvironment() {
         // Delete temp folder so we have no data

--- a/src/test/java/net/estools/Implementation/TestWorld.java
+++ b/src/test/java/net/estools/Implementation/TestWorld.java
@@ -1,16 +1,20 @@
 package net.estools.Implementation;
 
 import net.estools.ServerApi.EsLocation;
+import net.estools.ServerApi.Interfaces.EsBlock;
 import net.estools.ServerApi.Interfaces.EsEntity;
 import net.estools.ServerApi.Interfaces.EsWorld;
+import net.estools.ServerApi.Position;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
 @SuppressWarnings("unused")  // For future
 public class TestWorld implements EsWorld {
     private final List<EsEntity> entities = new ArrayList<>();
+    private final List<Position> blocks = new ArrayList<>();
     private final String name;
     private final UUID uuid;
     private long time;
@@ -45,6 +49,10 @@ public class TestWorld implements EsWorld {
         entities.add(entity);
     }
 
+    public void addBlock(int x, int y, int z) {
+        blocks.add(new Position(x, y, z));
+    }
+
     // IMPLEMENTATIONS
 
     @Override
@@ -74,6 +82,20 @@ public class TestWorld implements EsWorld {
             }
         }
         return nearby;
+    }
+
+    @Override
+    public EsBlock getHighestBlockAt(int x, int z) {
+        Position highest = blocks
+                .stream()
+                .filter(b -> b.getX() == x && b.getZ() == z)
+                .max(Comparator.comparingInt(p -> (int) p.getY()))
+                .orElse(null);
+        if (highest == null) {
+            return null;
+        }
+
+        return new TestBlock("stone", (int) highest.getX(), (int) highest.getY(), (int) highest.getZ());
     }
 
     @Override


### PR DESCRIPTION
Add `/top` command to teleport the player to the highest block at their coordinates.

The first commit in this PR was [written by GitHub Workspace](https://copilot-workspace.githubnext.com/CoPokBl/EsTools?shareId=923523ca-966d-47cc-b23d-80033bacba74).
The second commit is what was required before it was fine to merge.

This has been tested on:  
- 1.21
- 1.0

It is highly unlikely that there were API changes that would break the in between versions.